### PR TITLE
✨ fix: update Subscription link in search dialog for correct routing

### DIFF
--- a/src/components/nav/search-dialog.tsx
+++ b/src/components/nav/search-dialog.tsx
@@ -68,7 +68,7 @@ const settingsActions = [
   },
   {
     label: "Subscription",
-    href: "/api/portal",
+    href: "/subscription",
     icon: CreditCard,
   },
 ];


### PR DESCRIPTION
- Changed the href for the Subscription action from "/api/portal" to "/subscription" to ensure proper navigation.