### PR TITLE
✨ feat: add loading skeletons for Blogs and Explore pages

### DIFF
--- a/src/app/(protected)/blogs/loading.tsx
+++ b/src/app/(protected)/blogs/loading.tsx
@@ -1,0 +1,29 @@
+import { BlogsSkeleton } from "@/components/pages/blogs";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function BlogsPageSkeletonLoading() {
+  return (
+    <main className="container mx-auto p-6 lg:p-8 space-y-6 lg:space-y-8">
+      {/* Banner Skeleton */}
+      <div className="rounded-3xl bg-linear-to-r from-primary/5 via-background/50 to-background dark:from-primary/10 dark:via-background/90 dark:to-background p-6 sm:p-8 lg:p-12">
+        <div className="flex items-center gap-4 mb-4">
+          <Skeleton className="h-6 w-48" /> {/* Badge */}
+        </div>
+        <Skeleton className="h-8 w-64 mb-4" /> {/* Title */}
+        <Skeleton className="h-6 w-3/4" /> {/* Description */}
+      </div>
+
+      {/* Tabs Skeleton */}
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-24" /> /* Tab triggers */
+          ))}
+        </div>
+
+        {/* Content Skeleton */}
+        <BlogsSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/src/app/(protected)/blogs/page.tsx
+++ b/src/app/(protected)/blogs/page.tsx
@@ -15,11 +15,7 @@ export const metadata: Metadata = {
 };
 
 export default async function BlogsPage() {
-  await Promise.all([
-    api.blog.getUserPosts.prefetch({}),
-    api.blog.getUserPosts.prefetch({ status: "published" }),
-    api.blog.getUserPosts.prefetch({ status: "draft" }),
-  ]);
+  await api.blog.getUserPosts.prefetch({});
 
   const tabOptions = [
     { value: "all", label: "All" },

--- a/src/app/(protected)/explore/loading.tsx
+++ b/src/app/(protected)/explore/loading.tsx
@@ -1,0 +1,29 @@
+import { BlogsSkeleton } from "@/components/pages/blogs";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function ExplorePageSkeletonLoading() {
+  return (
+    <main className="container mx-auto p-6 lg:p-8 space-y-6 lg:space-y-8">
+      {/* Banner Skeleton */}
+      <div className="rounded-3xl bg-linear-to-r from-primary/5 via-background/50 to-background dark:from-primary/10 dark:via-background/90 dark:to-background p-6 sm:p-8 lg:p-12">
+        <div className="flex items-center gap-4 mb-4">
+          <Skeleton className="h-6 w-48" /> {/* Badge */}
+        </div>
+        <Skeleton className="h-8 w-64 mb-4" /> {/* Title */}
+        <Skeleton className="h-6 w-3/4" /> {/* Description */}
+      </div>
+
+      {/* Tabs Skeleton */}
+      <div className="space-y-2">
+        <div className="flex gap-2">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-24" /> /* Tab triggers */
+          ))}
+        </div>
+
+        {/* Content Skeleton */}
+        <BlogsSkeleton />
+      </div>
+    </main>
+  );
+}

--- a/src/components/pages/blogs/explore-client.tsx
+++ b/src/components/pages/blogs/explore-client.tsx
@@ -8,11 +8,11 @@ import { type CategoryType } from "@/server/db/schema";
 import { api } from "@/trpc/react";
 
 interface ExploreClientProps {
-  category: CategoryType;
+  category?: CategoryType;
 }
 
 export default function ExploreClient({ category }: ExploreClientProps) {
-  const [blogs] = api.blog.getPostsByCategory.useSuspenseQuery({
+  const [blogs] = api.blog.listPosts.useSuspenseQuery({
     category,
   });
 


### PR DESCRIPTION
This pull request introduces skeleton loading components for the `Blogs` and `Explore` pages to improve user experience during data fetching, alongside updates to the data fetching logic to simplify and optimize API calls. The most important changes include adding reusable skeleton components, refactoring tab options, and updating API usage for better efficiency.

### Skeleton Loading Components:
* **`src/app/(protected)/blogs/loading.tsx`**: Added a skeleton loading component (`BlogsPageSkeletonLoading`) for the `Blogs` page, featuring placeholders for banner, tabs, and content.
* **`src/app/(protected)/explore/loading.tsx`**: Added a skeleton loading component (`ExplorePageSkeletonLoading`) for the `Explore` page, with placeholders for banner, tabs, and content, including more tab triggers compared to the `Blogs` page.

### Data Fetching Optimization:
* **`src/app/(protected)/blogs/page.tsx`**: Simplified API prefetching by removing redundant calls for specific post statuses (`published`, `draft`) and using a single call for all user posts.
* **`src/app/(protected)/explore/page.tsx`**: Consolidated API calls to prefetch all posts and categories, enabling dynamic tab options for categories and an "All" tab. Updated `Tabs` and `TabsContent` to use the new `tabOptions` structure. [[1]](diffhunk://#diff-6eef67284c7a722e7eaa07e18f3063d931d2cbeb1dd3cfc1044a7bb58a7e3495L18-R30) [[2]](diffhunk://#diff-6eef67284c7a722e7eaa07e18f3063d931d2cbeb1dd3cfc1044a7bb58a7e3495L35-R62)

### API Usage Updates:
* **`src/components/pages/blogs/explore-client.tsx`**: Modified the `ExploreClient` component to accept an optional `category` parameter and switched from `getPostsByCategory` to `listPosts` for querying posts, aligning with the new data fetching strategy.